### PR TITLE
Add GitHub Action to build IA32 UefiPayload

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -6,7 +6,7 @@ on:
   - push
 
 jobs:
-  build:
+  UefiPayloadPkgIA32:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
@@ -30,14 +30,48 @@ jobs:
         run: |
           make -C BaseTools
 
-      - name: Build default X64 UefiPayload
+      - name: Build IA32 UefiPayload
         run: |
-          export extraFlags=""
           source ./edksetup.sh
-          build $extraFlags -D BOOTLOADER=COREBOOT -a IA32 -a X64 -t GCC5 -b DEBUG -p UefiPayloadPkg/UefiPayloadPkgIa32X64.dsc
+          build -D BOOTLOADER=COREBOOT -a IA32 -t GCC5 -b DEBUG -p UefiPayloadPkg/UefiPayloadPkgIa32.dsc
 
-      - name: Upload default X64 UefiPayload
+      - name: Upload IA32 UefiPayload
         uses: actions/upload-artifact@v2
         with:
-          name: DEFAULT_UEFIPAYLOAD.fd
+          name: UEFIPAYLOAD_IA32.fd
+          path: Build/UefiPayloadPkgIA32/DEBUG_GCC5/FV/UEFIPAYLOAD.fd
+
+  UefiPayloadPkgX64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: |
+          DEBIAN_FRONTEND=noninteractive sudo apt-get -qq update
+          DEBIAN_FRONTEND=noninteractive sudo apt-get -qqy install \
+          git python3 python3-distutils-extra build-essential nasm iasl uuid-dev
+          DEBIAN_FRONTEND=noninteractive sudo apt-get clean
+          sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 1337
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Update submodules
+        run: |
+          git submodule init
+          git submodule sync --recursive
+          git submodule update --recursive
+
+      - name: Build BaseTools
+        run: |
+          make -C BaseTools
+
+      - name: Build X64 UefiPayload
+        run: |
+          source ./edksetup.sh
+          build -D BOOTLOADER=COREBOOT -a IA32 -a X64 -t GCC5 -b DEBUG -p UefiPayloadPkg/UefiPayloadPkgIa32X64.dsc
+
+      - name: Upload X64 UefiPayload
+        uses: actions/upload-artifact@v2
+        with:
+          name: UEFIPAYLOAD_X64.fd
           path: Build/UefiPayloadPkgX64/DEBUG_GCC5/FV/UEFIPAYLOAD.fd


### PR DESCRIPTION
Add job to also build IA32 UefiPayload target.
Currently it is broken in tianocore/master.

Signed-off-by: Marcello Sylvester Bauer <marcello.bauer@9elements.com>