### PR TITLE
UefiPayloadPkg: Boot menu configuration enabling

### DIFF
--- a/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
+++ b/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
@@ -1171,7 +1171,9 @@ BdsEntry (
     // Execute Key####
     //
     PERF_INMODULE_BEGIN ("BdsWait");
-    BdsWait (HotkeyTriggered);
+    if (PcdGet16 (PcdPlatformBootTimeOut) != 0) {
+      BdsWait (HotkeyTriggered);
+    }
     PERF_INMODULE_END ("BdsWait");
     //
     // BdsReadKeys() can be removed after all keyboard drivers invoke callback in timer callback.

--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -158,10 +158,12 @@ PlatformBootManagerBeforeConsole (
   //
   // Map Escape to Boot Manager Menu
   //
-  Escape.ScanCode    = SCAN_ESC;
-  Escape.UnicodeChar = CHAR_NULL;
-  EfiBootManagerGetBootManagerMenu (&BootOption);
-  EfiBootManagerAddKeyOptionVariable (NULL, (UINT16) BootOption.OptionNumber, 0, &Escape, NULL);
+  if (PcdGet16 (PcdPlatformBootTimeOut) > 0) {
+    Escape.ScanCode    = SCAN_ESC;
+    Escape.UnicodeChar = CHAR_NULL;
+    EfiBootManagerGetBootManagerMenu (&BootOption);
+    EfiBootManagerAddKeyOptionVariable (NULL, (UINT16) BootOption.OptionNumber, 0, &Escape, NULL);
+  }
 
   //
   // Install ready to lock.
@@ -226,7 +228,9 @@ PlatformBootManagerAfterConsole (
   PlatformRegisterFvBootOption (PcdGetPtr (PcdiPXEFileIp4), L"iPXE Network boot IPv4", LOAD_OPTION_ACTIVE);
   PlatformRegisterFvBootOption (PcdGetPtr (PcdiPXEFileIp6), L"iPXE Network boot IPv6", LOAD_OPTION_ACTIVE);
 
-  Print (L"Pess ESC to enter Boot Manager Menu.\n");
+  if (PcdGet16 (PcdPlatformBootTimeOut) > 0) {
+    Print (L"Pess ESC to enter Boot Manager Menu.\n");
+  }
 }
 
 /**

--- a/UefiPayloadPkg/SmbusConfigLoaderDxe/SMBusConfigLoader.h
+++ b/UefiPayloadPkg/SmbusConfigLoaderDxe/SMBusConfigLoader.h
@@ -14,6 +14,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <IndustryStandard/Pci22.h>
 #include <Protocol/SmbusHc.h>
 #include <Guid/BoardSettingsGuid.h>
+#include <Library/PcdLib.h>
 
 #define BOARD_SETTINGS_OFFSET   0x1f00
 #define BOARD_BOOT_OVERRIDE_OFFSET 0x1640

--- a/UefiPayloadPkg/SmbusConfigLoaderDxe/SMBusConfigLoader.inf
+++ b/UefiPayloadPkg/SmbusConfigLoaderDxe/SMBusConfigLoader.inf
@@ -32,6 +32,9 @@
   UefiPayloadPkg/UefiPayloadPkg.dec
   SecurityPkg/SecurityPkg.dec
 
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut
+
 [Guids]
   gEfiBoardSettingsVariableGuid
   gEfiSecureBootEnableDisableGuid


### PR DESCRIPTION
Enable EEPROM to disable the boot menu.

Signed-off-by: Lean Sheng Tan <sheng.tan@9elements.com>