### PR TITLE
[HACK] Do not allow booting Boot Manager if disabled

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
@@ -1782,6 +1782,7 @@ EfiBootManagerBoot (
   EFI_INPUT_KEY             Key;
   UINTN                     Index;
   UINT8                     *SecureBoot;
+  BOOLEAN                   IsBootManager;
 
   if (BootOption == NULL) {
     return;
@@ -1816,6 +1817,13 @@ EfiBootManagerBoot (
     }
   }
 
+  // Do not allow Boot Manager to be booted if disabled
+  IsBootManager = BmIsBootManagerMenuFilePath (BootOption->FilePath);
+  if (IsBootManager && PcdGet16 (PcdPlatformBootTimeOut) == 0) {
+      DEBUG ((EFI_D_ERROR, "[Bds] Booting Boot Manager is not allowed!\n"));
+      return;
+  }
+
   //
   // 2. Set BootCurrent
   //
@@ -1832,7 +1840,7 @@ EfiBootManagerBoot (
   // 3. Signal the EVT_SIGNAL_READY_TO_BOOT event when we are about to load and execute
   //    the boot option.
   //
-  if (BmIsBootManagerMenuFilePath (BootOption->FilePath)) {
+  if (IsBootManager) {
     DEBUG ((EFI_D_INFO, "[Bds] Booting Boot Manager Menu.\n"));
     BmStopHotkeyService (NULL, NULL);
   } else {

--- a/MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
+++ b/MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
@@ -118,3 +118,4 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdBootManagerMenuFile                     ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdDriverHealthConfigureForm               ## SOMETIMES_CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdMaxRepairCount                          ## CONSUMES
+  gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut                           ## SOMETIMES_CONSUMES


### PR DESCRIPTION
Tested by Prodrive it is working for now:
https://github.com/9elements/ProDrive_Hermes_BoardFiles/issues/1#issuecomment-1243430507

Signed-off-by: Angel Pons <th3fanbus@gmail.com>