### PR TITLE
UefiPayloadPkg-PlatformBootManager: Unregister unused pxe options

### DIFF
--- a/UefiPayloadPkg/Include/Guid/BoardSettingsGuid.h
+++ b/UefiPayloadPkg/Include/Guid/BoardSettingsGuid.h
@@ -46,6 +46,10 @@ typedef struct {
 #define PXE_BOOT_IP6      2
 #define PXE_BOOT_IP4_IP6  3
 
+#define PXE_DESCRIPTION_IP4_IP6 L"iPXE Network boot IPv4 and IPv6"
+#define PXE_DESCRIPTION_IP4 L"iPXE Network boot IPv4"
+#define PXE_DESCRIPTION_IP6 L"iPXE Network boot IPv6"
+
 typedef struct {
   UINT16 StructSize;
   UINT32 Checksum;

--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -139,6 +139,35 @@ PlatformRegisterFvBootOption (
   }
 }
 
+VOID
+PlatformUnregisterFvBootOption (
+  IN CHAR16 *Description
+  )
+{
+  EFI_BOOT_MANAGER_LOAD_OPTION *BootOptions;
+  UINTN                        BootOptionCount;
+  UINTN                        Index;
+
+  BootOptions = EfiBootManagerGetLoadOptions (&BootOptionCount,
+                  LoadOptionTypeBoot);
+
+  for (Index = 0; Index < BootOptionCount; ++Index) {
+    EFI_STATUS Status;
+    if (StrCmp(Description, BootOptions[Index].Description) != 0) {
+	  continue;
+    }
+
+    Status = EfiBootManagerDeleteLoadOptionVariable (
+               BootOptions[Index].OptionNumber, LoadOptionTypeBoot);
+    if(EFI_ERROR(Status)) {
+      DEBUG((DEBUG_ERROR, "Failed to delete boot option from variable\n"));
+    }
+    break;
+  }
+
+  EfiBootManagerFreeLoadOptions (BootOptions, BootOptionCount);
+}
+
 /**
   Do the platform specific action before the console is connected.
 
@@ -248,18 +277,27 @@ PlatformBootManagerAfterConsole (
   switch(PxeBootCapability) {
   case PXE_BOOT_IP4_IP6:
     DEBUG((DEBUG_INFO, "PxeBootCapability: %#x %#x\n", PXE_BOOT_IP4_IP6));
-    PlatformRegisterFvBootOption (PcdGetPtr (PcdiPXEFileIp4Ip6), L"iPXE Network boot IPv4 and IPV6", LOAD_OPTION_ACTIVE);
+    PlatformRegisterFvBootOption (PcdGetPtr (PcdiPXEFileIp4Ip6), PXE_DESCRIPTION_IP4_IP6, LOAD_OPTION_ACTIVE);
+    PlatformUnregisterFvBootOption(PXE_DESCRIPTION_IP4);
+    PlatformUnregisterFvBootOption(PXE_DESCRIPTION_IP6);
     break;
   case PXE_BOOT_IP6:
     DEBUG((DEBUG_INFO, "PxeBootCapability: %#x %#x\n", PXE_BOOT_IP6));
-    PlatformRegisterFvBootOption (PcdGetPtr (PcdiPXEFileIp6), L"iPXE Network boot IPv6", LOAD_OPTION_ACTIVE);
+    PlatformRegisterFvBootOption (PcdGetPtr (PcdiPXEFileIp6), PXE_DESCRIPTION_IP6, LOAD_OPTION_ACTIVE);
+    PlatformUnregisterFvBootOption(PXE_DESCRIPTION_IP4_IP6);
+    PlatformUnregisterFvBootOption(PXE_DESCRIPTION_IP4);
     break;
   case PXE_BOOT_IP4:
     DEBUG((DEBUG_INFO, "PxeBootCapability: %#x %#x\n", PXE_BOOT_IP4));
-    PlatformRegisterFvBootOption (PcdGetPtr (PcdiPXEFileIp4), L"iPXE Network boot IPv4", LOAD_OPTION_ACTIVE);
+    PlatformRegisterFvBootOption (PcdGetPtr (PcdiPXEFileIp4), PXE_DESCRIPTION_IP4, LOAD_OPTION_ACTIVE);
+    PlatformUnregisterFvBootOption(PXE_DESCRIPTION_IP4_IP6);
+    PlatformUnregisterFvBootOption(PXE_DESCRIPTION_IP6);
     break;
   case 0: //intentional fall-through
   default:
+    PlatformUnregisterFvBootOption(PXE_DESCRIPTION_IP4_IP6);
+    PlatformUnregisterFvBootOption(PXE_DESCRIPTION_IP6);
+    PlatformUnregisterFvBootOption(PXE_DESCRIPTION_IP4);
     DEBUG((DEBUG_INFO, "PxeBootCapability disabled\n"));
     break;
   }


### PR DESCRIPTION
PXE options can be chosen by the PxeBootCapability BIOS/SMBUS option, but if these settings are enabled after each other in the old implementation, they would still get added to the list as there was no mechanism removing them, so find and unregister pxe options that should not be loaded.

Signed-off-by: Justin van Son <justin.van.son@prodrive-technologies.com>