### PR TITLE
Allow the current registered pxe boot option as boot override

### DIFF
--- a/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
+++ b/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
@@ -738,22 +738,8 @@ IsBootTypeMatch(
 {
   switch (Override.Type) {
   case BootOverridePXE:
-    switch (Override.Port) {
-    default:
-      break;
-    case IPV4IPV6:
-      if (StrCmp(BootOption->Description, L"iPXE Network boot IPv4 and IPV6") == 0)
-        return 1;
-      break;
-    case IPV4:
-      if (StrCmp(BootOption->Description, L"iPXE Network boot IPv4") == 0)
-        return 1;
-      break;
-    case IPV6:
-      if (StrCmp(BootOption->Description, L"iPXE Network boot IPv6") == 0)
-        return 1;
-      break;
-    }
+    if(StrStr(BootOption->Description, L"iPXE Network boot") != NULL)
+      return 1;
     break;
   case BootOverrideSATA:
     if (BootOptionType(BootOption->FilePath) == MSG_SATA_DP) {

--- a/UefiPayloadPkg/Include/Guid/BoardSettingsGuid.h
+++ b/UefiPayloadPkg/Include/Guid/BoardSettingsGuid.h
@@ -65,12 +65,6 @@ enum BoardBootOverride {
   BootOverrideMax
 };
 
-enum iPXEBootOverride {
-  IPV4IPV6 = 0,
-  IPV4 = 1,
-  IPV6 = 2,
-};
-
 typedef struct {
   UINT8 Type;
   UINT8 Port;


### PR DESCRIPTION
In the BMC, it's a lot more difficult to get which pxe option is currently enabled, so fix it on firmware side

Signed-off-by: Justin van Son <justin.van.son@prodrive-technologies.com>